### PR TITLE
formatting definition lookup should uppercase DEFAULT

### DIFF
--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -53,7 +53,7 @@ class CurrencyFormatter(object):
         if locale in self.formatting_definitions:
             return self.formatting_definitions.get(locale)
         else:
-            return self.formatting_definitions.get(DEFAULT)
+            return self.formatting_definitions.get(DEFAULT.upper())
 
     def format(self, money, include_symbol=True, locale=DEFAULT,
                decimal_places=None, rounding_method=None):

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -120,6 +120,17 @@ class TestMoney:
         assert format_money(one_million_pln, locale='pl_PL',
                             decimal_places=0) == '1 000 000 zł'
 
+    def test_format_money_uses_default_formatting_definition_if_given_locale_not_registered(self):
+        m1 = Money(Decimal('100'), 'GBP')
+
+        # should format with 'default' formatting definition
+        expected_default_formatting = format_money(m1)
+
+        # should format with 'default' formatting definition since
+        # 'en_AU' is not a registered formatting definition
+        returned_formatting = format_money(m1, locale='en_AU')
+        assert returned_formatting == expected_default_formatting
+
     def test_add(self):
         assert (self.one_million_bucks + self.one_million_bucks
                 == Money(amount='2000000', currency=self.USD))


### PR DESCRIPTION
When a not-registered locale, such as `en_AU` used for formatting, `format` method raises `TypeError: 'NoneType' object has no attribute '__getitem__'` error since formatting definition doesn't properly falls back to `DEFAULT`. It's because `DEFAULT` is not being looked up as uppercase.

@emre-e @burakgoynuk can you have a check please?
