### PR TITLE
fallback to DEFAULT symbol definition if currency not available in sy…

### DIFF
--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -38,8 +38,9 @@ class CurrencyFormatter(object):
     def get_sign_definition(self, currency_code, locale):
         currency_code = currency_code.upper()
 
-        if (locale.upper() not in self.sign_definitions) or (
-                currency_code not in self.sign_definitions[locale.upper()]):
+        # fallback to default sign definition if either "locale" or
+        # "currency for that locale" not found
+        if currency_code not in self.sign_definitions.get(locale.upper(), {}):
             locale = DEFAULT
 
         local_set = self.sign_definitions.get(locale.upper())

--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -38,7 +38,8 @@ class CurrencyFormatter(object):
     def get_sign_definition(self, currency_code, locale):
         currency_code = currency_code.upper()
 
-        if locale.upper() not in self.sign_definitions:
+        if (locale.upper() not in self.sign_definitions) or (
+                currency_code not in self.sign_definitions[locale.upper()]):
             locale = DEFAULT
 
         local_set = self.sign_definitions.get(locale.upper())

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -10,7 +10,7 @@ import warnings
 import pytest  # Works with less code, more consistency than unittest.
 
 from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY, USD, get_currency
-from moneyed.localization import format_money
+from moneyed.localization import format_money, CurrencyFormatter
 
 
 class TestCurrency:
@@ -115,7 +115,7 @@ class TestMoney:
         one_million_pln = Money('1000000', 'PLN')
         # Two decimal places by default
         assert format_money(one_million_pln, locale='pl_PL') == '1 000 000,00 zł'
-        assert format_money(self.one_million_bucks, locale='pl_PL') == '1 000 000,00 USD'
+        assert format_money(self.one_million_bucks, locale='pl_PL') == 'US$1 000 000,00'
         # No decimal point without fractional part
         assert format_money(one_million_pln, locale='pl_PL',
                             decimal_places=0) == '1 000 000 zł'
@@ -292,6 +292,19 @@ class TestMoney:
     def test_bool(self):
         assert bool(Money(amount=1, currency=self.USD))
         assert not bool(Money(amount=0, currency=self.USD))
+
+
+class TestCurrencyFormatter:
+
+    def test_get_sign_definition_falls_back_to_default_if_currency_not_found_in_given_locale(self):
+        # should fall back to default since although 'en_US' symbol definition exists, it's only
+        # for 'USD' currency. So, for other currencies (not defined in symbol def list of 'USD'),
+        #  it should use DEFAULT symbols instead.
+        formatter = CurrencyFormatter()
+        returned_gbp_sign_definition = formatter.get_sign_definition('GBP', 'en_US')
+        expected_gbp_sign_definition = formatter.get_sign_definition('GBP', 'default')
+
+        assert expected_gbp_sign_definition == returned_gbp_sign_definition
 
 
 class ExtendedMoney(Money):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class Tox(TestCommand):
 setup(
     name='ud-py-moneyed',
     packages=['moneyed'],
-    version='0.6.2',
+    version='0.6.3',
     description='Provides Currency and Money classes for use in your Python code.',
     url='https://github.com/udemy/py-moneyed',
     download_url='',


### PR DESCRIPTION
Current code doesn't fall back to `DEFAULT` if a locale is defined but a symbol for a currency not defined. This makes definition of `DEFAULT` symbols meaningless. Hence, any overriding implementation had to create symbol override for all the other currencies instead of falling back/relying on the `DEFAULT` symbols.
This fix adds another check for whether symbol for that currency defined for given locale. If not, uses the `DEFAULT` symbol for that currency. By this way, for overriders, it'll be enough to define the `DEFAULT` symbols to customise the formatting.

@emre-e @burakgoynuk could you please have a check?
